### PR TITLE
Improve slug generation and token verification

### DIFF
--- a/api/utils/slug.js
+++ b/api/utils/slug.js
@@ -13,8 +13,16 @@
  * @returns {string} A slugified representation of the provided title.
  */
 export function generateSlug(title) {
-    return title
-        .trim()
+    if (typeof title !== 'string') {
+        throw new TypeError('Title must be a string');
+    }
+
+    const trimmed = title.trim();
+    if (trimmed === '') {
+        return '';
+    }
+
+    return trimmed
         .toLowerCase()
         // Remove all characters except letters, numbers, spaces and hyphens
         .replace(/[^a-z0-9\s-]/g, '')

--- a/api/utils/slug.test.js
+++ b/api/utils/slug.test.js
@@ -16,3 +16,15 @@ test('generateSlug collapses whitespace and trims hyphens', () => {
     const slug = generateSlug('  Multiple   Spaces -- and symbols!!!  ');
     assert.strictEqual(slug, 'multiple-spaces-and-symbols');
 });
+
+test('generateSlug returns empty string when given only whitespace', () => {
+    const slug = generateSlug('   ');
+    assert.strictEqual(slug, '');
+});
+
+test('generateSlug throws an error when input is not a string', () => {
+    assert.throws(() => generateSlug(123), {
+        name: 'TypeError',
+        message: 'Title must be a string',
+    });
+});

--- a/api/utils/verifyUser.js
+++ b/api/utils/verifyUser.js
@@ -1,15 +1,22 @@
 import jwt from 'jsonwebtoken';
 import { errorHandler } from './error.js';
+
 export const verifyToken = (req, res, next) => {
-  const token = req.cookies.access_token;
-  if (!token) {
-    return next(errorHandler(401, 'Unauthorized'));
-  }
-  jwt.verify(token, 'viren', (err, user) => {
-    if (err) {
-      return next(errorHandler(401, 'Unauthorized'));
+    const token = req.cookies?.access_token;
+    if (!token) {
+        return next(errorHandler(401, 'Unauthorized'));
     }
-    req.user = user;
-    next();
-  });
+
+    const secret = process.env.JWT_SECRET;
+    if (!secret) {
+        return next(errorHandler(500, 'JWT secret is missing'));
+    }
+
+    try {
+        const user = jwt.verify(token, secret);
+        req.user = user;
+        next();
+    } catch {
+        next(errorHandler(401, 'Unauthorized'));
+    }
 };


### PR DESCRIPTION
## Summary
- add explicit validation and trimming to generateSlug
- cover slug edge cases with new tests
- use environment variable and better error handling for JWT token verification

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68afd49f1e2883318b37cf0b0e43c182